### PR TITLE
Fix colored text not displaying on new player join

### DIFF
--- a/src/nu/nerd/nerdspawn/NerdSpawnListener.java
+++ b/src/nu/nerd/nerdspawn/NerdSpawnListener.java
@@ -29,7 +29,7 @@ public class NerdSpawnListener implements Listener
                 String message = plugin.getConfig().getString("join-message");
                 message = message.replaceAll("%u", event.getPlayer().getName());
                 for (ChatColor c : ChatColor.values())
-                    message = message.replaceAll("&" + Integer.toHexString(c.getChar()), c.toString());
+                    message = message.replaceAll(("&" + c.getChar()), c.toString());
 
                 plugin.getServer().broadcastMessage(message);
             }


### PR DESCRIPTION
Integer.toHexString(c.getChar()) returns an incorrect color code; c.getChar() is sufficient. 
In the config file, the line in question is "&5Welcome %u to the server!"; Integer.toHexString(c.getChar()) returns &35, and so the replaceAll for &5 fails. c.getChar() returns &5 and replacement succeeds.
